### PR TITLE
Fix duplicate definitions of test_name in tests

### DIFF
--- a/src/tests/userprog/compute-e.c
+++ b/src/tests/userprog/compute-e.c
@@ -4,9 +4,9 @@
 #include <float.h>
 #include "tests/lib.h"
 
-const char* test_name = "compute-e";
-
 int main(void) {
+  test_name = "compute-e";
+
   double e_res = sum_to_e(10);
   if (abs_val(e_res - E_VAL) < TOL) {
     msg("Success!");

--- a/src/tests/userprog/floating-point.c
+++ b/src/tests/userprog/floating-point.c
@@ -4,9 +4,9 @@
 #include "tests/lib.h"
 #include "tests/main.h"
 
-const char* test_name = "floating-point";
-
 void test_main(void) {
+  test_name = "floating-point";
+
   msg("Computing e...");
   double e_res = sum_to_e(10);
   if (abs_val(e_res - E_VAL) < TOL) {

--- a/src/tests/userprog/fp-asm-helper.c
+++ b/src/tests/userprog/fp-asm-helper.c
@@ -3,10 +3,11 @@
 #include "tests/lib.h"
 
 #define NUM_VALUES 4
-const char* test_name = "fp-asm-helper";
 static int values[NUM_VALUES] = {12, 14, 16, 18};
 
 int main(void) {
+  test_name = "fp-asm-helper";
+
   push_values_to_fpu(values, NUM_VALUES);
   return 0;
 }

--- a/src/tests/userprog/fp-asm.c
+++ b/src/tests/userprog/fp-asm.c
@@ -5,11 +5,11 @@
 #include "tests/lib.h"
 #include "tests/main.h"
 
-#define NUM_VALUES 4
-const char* test_name = "fp-asm";
-static int values[NUM_VALUES] = {1, 6, 2, 162};
+#define NUM_VALUES 4static int values[NUM_VALUES] = {1, 6, 2, 162};
 
 void test_main(void) {
+  test_name = "fp-asm";
+
   msg("Starting...");
   push_values_to_fpu(values, NUM_VALUES);
   wait(exec("fp-asm-helper"));

--- a/src/tests/userprog/fp-init.c
+++ b/src/tests/userprog/fp-init.c
@@ -5,9 +5,10 @@
 #include "tests/main.h"
 
 #define FPU_SIZE 108
-const char* test_name = "fp-init";
 
 void test_main(void) {
+  test_name = "fp-init";
+
   uint8_t fpu[FPU_SIZE];
   uint8_t init_fpu[FPU_SIZE];
   asm("fsave (%0); fninit; fsave (%1)" : : "g"(&fpu), "g"(&init_fpu));

--- a/src/tests/userprog/fp-kernel-e.c
+++ b/src/tests/userprog/fp-kernel-e.c
@@ -5,9 +5,9 @@
 #include "tests/lib.h"
 #include "tests/main.h"
 
-const char* test_name = "fp-kernel-e";
-
 void test_main(void) {
+  test_name = "fp-kernel-e";
+
   msg("Computing e...");
   double e_res = compute_e(10);
   if (abs_val(e_res - E_VAL) < TOL) {

--- a/src/tests/userprog/fp-simul.c
+++ b/src/tests/userprog/fp-simul.c
@@ -7,9 +7,9 @@
 #include "tests/lib.h"
 #include "tests/main.h"
 
-const char* test_name = "fp-simul";
-
 void test_main(void) {
+  test_name = "fp-simul";
+
   msg("Computing e...");
   pid_t e_pid = exec("compute-e");
   double e_res = sum_to_e(10);

--- a/src/tests/userprog/fp-syscall.c
+++ b/src/tests/userprog/fp-syscall.c
@@ -11,7 +11,6 @@
 
 #define FPU_SIZE 108
 #define NUM_VALUES 8
-const char* test_name = "fp-syscall";
 static int values[NUM_VALUES] = {1, 6, 2, 162, 126, 2, 6, 1};
 
 /* Invokes syscall NUMBER, passing argument ARG0, and returns the
@@ -27,6 +26,8 @@ static int values[NUM_VALUES] = {1, 6, 2, 162, 126, 2, 6, 1};
   })
 
 void test_main(void) {
+  test_name = "fp-syscall";
+
   uint8_t fpu_before[FPU_SIZE];
   uint8_t fpu_after[FPU_SIZE];
 


### PR DESCRIPTION
After some testing in the student VM upgraded to a newer version of GCC (Ubuntu 22.04), it appears that the inconsistent definition of `test_name` causes some issues with newer linkers that try to do weird things. This _should_ fix that.